### PR TITLE
adding in jmespath to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ansible==3.0.0
+# ansible required package for json_query https://github.com/ansible/ansible/issues/24319
+jmespath==0.10.0


### PR DESCRIPTION
jmespath is required to use json_query in ansible.  Unclear why the package is not included during ansible install.  https://github.com/ansible/ansible/issues/24319

MR is to add the package so the ansiblecontroller can successfully parse json.